### PR TITLE
Update comments-walker.php

### DIFF
--- a/generators/app/templates/_/inc/comments-walker.php
+++ b/generators/app/templates/_/inc/comments-walker.php
@@ -33,7 +33,7 @@ class <%= theme_slug %>_Comments_Walker extends Walker_Comment {
         if ($depth) $comment_depth = $depth;
         if ($currentComment) $comment = $currentComment;
     }
-    function start_el( &$output, $comment, $depth, $args, $id = 0 ) {
+    function start_el( &$output, $comment, $depth = 0, $args = 0, $id = 0 ) {
         $this->setGlobals( $depth, $comment );
         $depth++;
         $this->current_comment_depth = $depth;


### PR DESCRIPTION
When on PHP 7.0.8 using Laragon, Debug error found. `themename_Comments_Walker::start_el(&$output, $comment, $depth, $args, $id = 0) should be compatible with Walker_Comment::start_el(&$output, $comment, $depth = 0, $args = Array, $id = 0) in C:\laragon\www\theme-path\wp-content\themes\themepath\inc\comments-walker.php on line 82`
